### PR TITLE
Adds Preemptive Memory Limiter for Managing Memory Leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
 dist
 sign.key
 .env
+CMakeFiles
+
+CPackConfig.cmake
+CPackSourceConfig.cmake
+Makefile
+VERSION
+cmake_install.cmake
+tiniConfig.h
+.editorconfig
+.python-version
+*.pyc

--- a/test/oom/Dockerfile.oom.test
+++ b/test/oom/Dockerfile.oom.test
@@ -1,0 +1,13 @@
+FROM alpine:3.7
+
+RUN apk add --no-cache bash vim alpine-sdk cmake
+
+ADD . /build
+WORKDIR /build
+
+RUN cmake .
+RUN make
+
+RUN gcc test/oom/leak.c -o leak
+
+CMD ["./tini", "-v", "-v", "-v", "-m", "./leak"]

--- a/test/oom/leak.c
+++ b/test/oom/leak.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <signal.h>
+
+static unsigned int retry = 0;
+
+void nope(int sig_num) {
+	printf("\nGo AWAY\n");
+
+	if (retry > 3) {
+		printf("\nFine!\n");
+		exit(0);
+	}
+
+	retry++;
+}
+
+int main() {
+	printf("Going to eat your memories!\n");
+	/* signal(SIGTERM, nope); */
+
+	while(1) {
+		malloc(200 * sizeof(int));
+		usleep(2);
+	}
+
+	return 0;
+}

--- a/test/run_oom_tests.py
+++ b/test/run_oom_tests.py
@@ -1,0 +1,25 @@
+from run_outer_tests import Command
+
+def main():
+    Command([
+        "docker",
+        "build",
+        "-t",
+        "leak",
+        "-f",
+        "./test/oom/Dockerfile.oom.test",
+        "./",
+    ], "").run(retcode=0)
+
+    Command([
+        "docker",
+        "run",
+        "--memory",
+        "32M",
+        "-e",
+        "TINI_PREEMPTIVE_MEMORY_LIMITER_THRESHOLD=50",
+        "leak"
+    ], "").run(retcode=143)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Adds Preemptive Memory Limiter

Adds a new -m option that when enabled will check the memory limit and usage of the process via the cgroup. When within 10% of the limit, a SIGTERM is sent. This should allow for bette 
memory control for applications that _should_ OOM but grind on their last 10% or so.

## What

Docker's default init script is `tini`, this change extends `tini` to monitor current memory usage via the cgroup. This allows `tini` to interrogate the amount of memory remaining. When 10% of memory is left, `tini` will attempt to SIGTERM the process. It will continue to try until the process comes down.

## Why

We have a number of applications in production with slow memory leaks (e.g. lp-ui, lp-api, cms-api, rql, and bouncer). With all of these applications we've observed the application grow to the limit, but then swap until the application is manually restarted. Docker/ECS should be reaping the instance, but the OOM never comes. 

This gives us a few more knobs to correct this behavior.

## Just Fix the Leaks

We should! We will! This is a bandaid at best, and shouldn't be used as any type of permanent solution. There are a number of better options that we will and should explore to make these errors safer, louder, and more actionable.